### PR TITLE
Bump alibuild to 1.5.5

### DIFF
--- a/alidock/cc7/Dockerfile
+++ b/alidock/cc7/Dockerfile
@@ -4,7 +4,7 @@ ADD alonid-llvm-3.9.0.repo /etc/yum.repos.d/alonid-llvm-3.9.0.repo
 ADD xpra.repo /etc/yum.repos.d/xpra.repo
 RUN rpmdb --rebuilddb && yum clean all && rm -rf /var/cache/yum && \
     yum install -y xcalc tmux htop bash-completion tig pigz nano ninja-build clang-3.9.0 xterm && \
-    yum install -y xpra-2.5-0.r22138.el7_6.x86_64 && \
+    yum install -y xpra-3.0.1 && \
     ln -nfs /usr/bin/ninja-build /usr/local/bin/ninja && \
     ln -nfs /opt/llvm-3.9.0/bin/* /usr/local/bin/ && \
     yum clean all && rm -rf /var/cache/yum

--- a/alidock/cc7/Dockerfile
+++ b/alidock/cc7/Dockerfile
@@ -27,4 +27,4 @@ RUN cd /tmp && \
 RUN cd /usr/local/bin && \
     curl -L https://github.com/direnv/direnv/releases/download/v2.20.0/direnv.linux-amd64 -o direnv && \
     chmod 0755 direnv
-RUN pip install alibuild==v1.5.4
+RUN pip install alibuild==v1.5.5

--- a/alidock/slc6/Dockerfile
+++ b/alidock/slc6/Dockerfile
@@ -17,4 +17,4 @@ RUN cd /tmp && \
     ./install && \
     cd .. && \
     rm -rf hub-linux*
-RUN pip install alibuild==v1.5.4
+RUN pip install alibuild==v1.5.5


### PR DESCRIPTION
@mconcas I hope to have modified all the relevant code. Maybe wait few days to merge, I don't know if at the tutorial of tomorrow alidock will be used but it is better to be safe. 

Update: it looks like the CI has a problem in installing `xpra` at the moment