### PR TITLE
Add parallel to cc7 build

### DIFF
--- a/alidock/cc7/Dockerfile
+++ b/alidock/cc7/Dockerfile
@@ -3,7 +3,7 @@ LABEL maintainer="Matteo Concas <mconcas@cern.ch>"
 ADD alonid-llvm-3.9.0.repo /etc/yum.repos.d/alonid-llvm-3.9.0.repo
 ADD xpra.repo /etc/yum.repos.d/xpra.repo
 RUN rpmdb --rebuilddb && yum clean all && rm -rf /var/cache/yum && \
-    yum install -y xcalc tmux htop bash-completion tig pigz nano ninja-build clang-3.9.0 xterm && \
+    yum install -y xcalc tmux htop bash-completion tig pigz nano ninja-build clang-3.9.0 xterm parallel && \
     yum install -y xpra-3.0.10 && \
     ln -nfs /usr/bin/ninja-build /usr/local/bin/ninja && \
     ln -nfs /opt/llvm-3.9.0/bin/* /usr/local/bin/ && \


### PR DESCRIPTION
The package parallel is currently used in the O2 HF developments. It would be nice to have it already installed. 