### PR TITLE
Bump aliBuild to 1.6.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,9 @@
-dist: trusty
+dist: bionic
 language: python
 services:
   - docker
 python:
   - "3.7-dev"
-before_install:
-  - sudo apt-get install realpath
 install:
   - pip install alidock
 before_script: |

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ services:
 python:
   - "3.7-dev"
 install:
-  - pip install alidock
+  - pip install git+https://github.com/alidock/alidock.git@master
 before_script: |
   export -f travis_nanoseconds
   export -f travis_fold

--- a/alidock/cc7/Dockerfile
+++ b/alidock/cc7/Dockerfile
@@ -27,4 +27,4 @@ RUN cd /tmp && \
 RUN cd /usr/local/bin && \
     curl -L https://github.com/direnv/direnv/releases/download/v2.20.0/direnv.linux-amd64 -o direnv && \
     chmod 0755 direnv
-RUN pip install alibuild==v1.6.2
+RUN pip install alibuild==v1.6.4

--- a/alidock/cc7/README.md
+++ b/alidock/cc7/README.md
@@ -1,6 +1,6 @@
 alipier/alidock:cc7
 ===================
 
-This is the current default image used by [alidock](https://github.com/alidock/alidock). It is based
+This is the clone of current default image used by [alidock](https://github.com/alidock/alidock). It is based
 on `alisw/slc7-builder`, the one currently used by ALICE to run the Continuous Integration and
 builds for Run 3 software.

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/bash -ex
 
 set -o pipefail
 cd "$(dirname "$0")"

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -ex
+#!/bin/bash -e
 
 set -o pipefail
 cd "$(dirname "$0")"
@@ -53,6 +53,8 @@ if [[ $DOCKER_PUSH ]]; then
                  -p "$(eval echo \$DOCKER_PASS_${DOCKER_ORG})"
   fold_end
 fi
+
+docker info
 
 # Gather list of what's changed
 fold_start list_changed "List of changed files and related symlinks"

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -88,6 +88,7 @@ for DOCK in "${CHANGED[@]}"; do
 
     fold_start alidock_exec "Test alidock with $DOCKER_IMAGE"
       $DRY_PREFIX alidock stop
+      $DRY_PREFIX alidock --version
       HELLO_WORLD=$($DRY_PREFIX alidock --no-update-image --image "$DOCKER_IMAGE" exec /bin/echo -n "$EXPECTED_HELLO_WORLD" | tail -n1)
       if [[ "$HELLO_WORLD" != "$EXPECTED_HELLO_WORLD" && ! $DRY_PREFIX ]]; then
         fatal "Container $DOCKER_IMAGE seems not to be usable with $(alidock --version)"


### PR DESCRIPTION
In the new alibuild version S3 support is added. I checked and the packages are correctly retrieved from the new repository.
This should resolve the recent problems with alicache